### PR TITLE
Allow edge label offset for undirected graphs

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -184,8 +184,8 @@ function gplot{T<:Real}(G,
             j = _dst_index(e, G)
             mid_x = (locs_x[i]+locs_x[j])/2.0
             mid_y = (locs_y[i]+locs_y[j])/2.0
-            edge_locs_x[e_idx] = _is_directed(G) ? (mid_x+locs_x[j])/2.0 : mid_x + edgelabeldistx*NODESIZE
-            edge_locs_y[e_idx] = _is_directed(G) ? (mid_y+locs_y[j])/2.0 : mid_y + edgelabeldisty*NODESIZE
+            edge_locs_x[e_idx] = (_is_directed(G) ? (mid_x+locs_x[j])/2.0 : mid_x) + edgelabeldistx*NODESIZE
+            edge_locs_y[e_idx] = (_is_directed(G) ? (mid_y+locs_y[j])/2.0 : mid_y) + edgelabeldisty*NODESIZE
         end
         edgetexts = text(edge_locs_x, edge_locs_y, map(string, edgelabel), [hcenter], [vcenter])
     end


### PR DESCRIPTION
Fix #23. @sbromberger could you please review and merge? This can also be included before the new tag.