### PR TITLE
fix deprecation warning for layout

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -57,7 +57,7 @@ function circular_layout(G)
     else
         # Discard the extra angle since it matches 0 radians.
         θ = linspace(0, 2pi, _nv(G) + 1)[1:end-1]
-        return cos(θ), sin(θ)
+        return cos.(θ), sin.(θ)
     end
 end
 
@@ -177,7 +177,7 @@ Vector of Vector, Vector of node Vector for each shell.
 **Examples**
 ```
 julia> g = graphfamous("karate")
-julia> nlist = Array(Vector{Int}, 2)
+julia> nlist = Array{Vector{Int}}(2)
 julia> nlist[1] = [1:5]
 julia> nlist[2] = [6:num_vertiecs(g)]
 julia> locs_x, locs_y = shell_layout(g, nlist)
@@ -188,7 +188,7 @@ function shell_layout(G, nlist::Union{Void, Vector{Vector{Int}}} = nothing)
         return [0.0], [0.0]
     end
     if nlist == nothing
-        nlist = Array(Vector{Int}, 1)
+        nlist = Array{Vector{Int}}(1)
         nlist[1] = collect(1:_nv(G))
     end
     radius = 0.0
@@ -200,8 +200,8 @@ function shell_layout(G, nlist::Union{Void, Vector{Vector{Int}}} = nothing)
     for nodes in nlist
         # Discard the extra angle since it matches 0 radians.
         θ = linspace(0, 2pi, length(nodes) + 1)[1:end-1]
-        append!(locs_x, radius*cos(θ))
-        append!(locs_y, radius*sin(θ))
+        append!(locs_x, radius*cos.(θ))
+        append!(locs_y, radius*sin.(θ))
         radius += 1.0
     end
     locs_x, locs_y

--- a/src/stress.jl
+++ b/src/stress.jl
@@ -63,7 +63,7 @@ function stressmajorize_layout(G, p::Int=2, w=nothing, X0=randn(_nv(G), p);
 
     if w==nothing
         w = δ.^-2
-        w[!isfinite(w)] = 0
+        w[.!isfinite.(w)] = 0
     end
 
     @assert size(X0, 1)==size(δ, 1)==size(δ, 2)==size(w, 1)==size(w, 2)
@@ -76,7 +76,7 @@ function stressmajorize_layout(G, p::Int=2, w=nothing, X0=randn(_nv(G), p);
     for iter = 1:maxiter
         #TODO the faster way is to drop the first row and col from the iteration
         X = pinvLw * (LZ(X0, δ, w)*X0)
-        @assert all(isfinite(X))
+        @assert all(isfinite.(X))
         newstress, oldstress = stress(X, δ, w), newstress
         verbose && info("""Iteration $iter
         Change in coordinates: $(vecnorm(X - X0))
@@ -109,7 +109,7 @@ function stress(X, d=fill(1.0, size(X, 1), size(X, 1)), w=nothing)
     n = size(X, 1)
     if w==nothing
         w = d.^-2
-        w[!isfinite(w)] = 0
+        w[!isfinite.(w)] = 0
     end
     @assert n==size(d, 1)==size(d, 2)==size(w, 1)==size(w, 2)
     for j=1:n, i=1:j-1
@@ -162,8 +162,6 @@ function LZ(Z, d, w)
         end
         L[i, i] = D
     end
-    @assert all(isfinite(L))
+    @assert all(isfinite.(L))
     L
 end
-
-


### PR DESCRIPTION
fix  deprecation warning for circular_layout, shell_layout and stressmajorize_layout.