### PR TITLE
WIP: bitmap nodes

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -55,12 +55,12 @@ julia> g = simple_house_graph()
 julia> locs_x, locs_y = circular_layout(g)
 ```
 """
-function circular_layout(g)
+function circular_layout(g::AbstractGraph{T}) where {T<:Integer}
     if nv(g) == 1
         return [0.0], [0.0]
     else
         # Discard the extra angle since it matches 0 radians.
-        θ = range(0, stop=2pi, length=_nv(G)+1)[1:end-1]
+        θ = range(0, stop=2pi, length=nv(g)+1)[1:end-1]
         return cos.(θ), sin.(θ)
     end
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -107,6 +107,7 @@ function gplot(g::AbstractGraph{T},
     nodefillc = colorant"turquoise",
     nodestrokec = nothing,
     nodestrokelw = 0.0,
+    node_bitmap = [],
     arrowlengthfrac = is_directed(g) ? 0.1 : 0.0,
     arrowangleoffset = π / 9.0,
     linetype = "straight",
@@ -163,7 +164,15 @@ function gplot(g::AbstractGraph{T},
             	    	nodecircle[i] *= nodesize[i]
         	    end
     	end
-    nodes = circle(locs_x, locs_y, nodecircle)
+
+    if isempty(node_bitmap)
+        nodes = circle(locs_x, locs_y, nodecircle)
+    else
+        bsize = 3*nodesize
+        xc = locs_x .- bsize/2
+        yc = locs_y .- bsize/2
+        nodes = bitmap(["image/png"], node_bitmap, xc, yc, [bsize], [bsize])
+    end
 
     # Create node labels if provided
     texts = nothing
@@ -216,9 +225,11 @@ function gplot(g::AbstractGraph{T},
     compose(context(units=UnitBox(-1.2, -1.2, +2.4, +2.4)),
             compose(context(), texts, fill(nodelabelc), stroke(nothing), fontsize(nodelabelsize)),
             compose(context(), nodes, fill(nodefillc), stroke(nodestrokec), linewidth(nodestrokelw)),
+            #compose(context(), nodes),
             compose(context(), edgetexts, fill(edgelabelc), stroke(nothing), fontsize(edgelabelsize)),
             compose(context(), arrows, stroke(edgestrokec), linewidth(edgelinewidth)),
             compose(context(), lines, stroke(edgestrokec), fill(nothing), linewidth(edgelinewidth)))
+
 end
 
 function gplot(g; layout::Function=spring_layout, keyargs...)


### PR DESCRIPTION
Answering #74 

usage example: 
```julia
logo_urls = [
    "https://github.com/JuliaFEM/JuliaFEM.jl/raw/master/docs/logo/JuliaFEMLogo_96x96.png",
    "https://user-images.githubusercontent.com/25916/36773410-843e61b0-1c7f-11e8-818b-3edb08da8f41.png",
    "http://docs.juliadiffeq.org/v2.0.0/assets/logo.png",
    "https://raw.githubusercontent.com/JuliaLang/IJulia.jl/master/deps/ijulialogo.png"
]

fnames = []
for logo in logo_urls
    fname = tempname()
    push!(fnames,fname)
    download(logo,fname)
end

logos = read.(fnames)

g = SimpleGraph(ones(Int,length(fnames),length(fnames)))

simg = gplot(g, node_bitmap=logos)
```
![image](https://user-images.githubusercontent.com/12501534/49035581-e18c9580-f1bd-11e8-9339-a65e4e4f0a87.png)

The current problem is the horizontal light gray line under the logos especially if the logo is transparent like highest one at the above picture. 