### PR TITLE
Kamada kawai

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,17 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+Compose = "0.7"
+LightGraphs = "1.1"
+VisualRegressionTests = "0.2"
 
 [extras]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
@@ -22,8 +29,3 @@ VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
 test = ["Test", "Cairo", "ImageMagick", "VisualRegressionTests"]
-
-[compat]
-"Compose" = "0.7"
-"LightGraphs" = "1.1"
-"VisualRegressionTests" = "0.2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,5 @@ Colors
 ColorTypes
 Compose 0.7.0
 LightGraphs 1.1.0
+Optim
+Distances

--- a/src/KamadaKawai.jl
+++ b/src/KamadaKawai.jl
@@ -1,0 +1,87 @@
+import Optim
+using Distances
+function kamada_kawai_layout(G, X=nothing; C= 1.0, MAXITER=100 )
+    Offset = 0.0
+    if X===nothing
+        locs_x = zeros(nv(G))
+        locs_y = zeros(nv(G))
+    else
+        locs_x = X[1]
+        locs_y = X[2]
+    end
+
+    function Objective(M,K)
+        D = pairwise(Euclidean(),M, dims=2)
+        D-= K
+        R = sum(D.^2)/2
+        return R
+    end
+
+    function dObjective!(dR,M,K)
+        dR .= zeros(size(M))
+        Vs = size(M,2)
+        D = pairwise(Euclidean(),M, dims=2)
+        D += I # Prevent division by zero
+        D .= K./D # Use negative for simplicity, since diag K = 0 everything is fine.
+        D .-= 1.0 # (K-(D+I))./(D+I) = K./(D+I) .- 1.0
+        D += I # Remove the false diagonal
+        for v1 in 1:Vs
+            dR[:,v1] .= -M[:,v1]*sum(D[:,v1])
+        end
+        dR .+= M*D
+        dR .*=2
+        return dR
+    end
+
+    function scaler(z, a, b)
+        2.0*((z - a)/(b - a)) - 1.0
+    end
+    # Stack individual graphs next to each other
+    for SubGraphVertices in connected_components(G)
+        SubGraph = induced_subgraph(G,SubGraphVertices)[1]
+        N = nv(SubGraph)
+        if X !== nothing
+            _locs_x = locs_x[SubGraphVertices]
+            _locs_y = locs_y[SubGraphVertices]
+        else
+            Vertices=collect(vertices(SubGraph))
+            Vmax=findmax([degree(SubGraph,x) for x in vertices(SubGraph)])[2]
+            filter!(x->x!=Vmax, Vertices)
+            Shells=[[Vmax]]
+            VComplement = copy(Shells[1])
+            while length(Vertices)>0
+                Interim = filter(x->!(x ∈ VComplement),vcat([collect(neighbors(SubGraph,s)) for s in Shells[end]]...))
+                unique!(Interim)
+                push!(Shells,Interim)
+                filter!(x->!(x ∈ Shells[end]),Vertices)
+                append!(VComplement,Shells[end])
+            end
+            _locs_x, _locs_y = shell_layout(SubGraph,Shells)
+        end
+
+        # The optimal distance between vertices
+        # Currently only LightGraphs are supported using the Dijkstra shortest path algorithm
+        K = zeros(N,N)
+        for v in 1:N
+            K[:,v] = dijkstra_shortest_paths(SubGraph,v).dists
+        end
+
+        M0 =  vcat(_locs_x',_locs_y')
+        OptResult = Optim.optimize(x->Objective(x,K),(x,y) -> dObjective!(x,y,K), M0, method=Optim.LBFGS(),iterations = MAXITER )
+        M0 = Optim.minimizer(OptResult)
+        min_x, max_x = minimum(M0[1,:]), maximum(M0[1,:])
+        min_y, max_y = minimum(M0[2,:]), maximum(M0[2,:])
+        map!(z -> scaler(z, min_x, max_x), M0[1,:], M0[1,:])
+        map!(z -> scaler(z, min_y, max_y), M0[2,:], M0[2,:])
+        locs_x[SubGraphVertices] .= M0[1,:] .+ Offset
+        locs_y[SubGraphVertices] .= M0[2,:]
+        Offset += maximum(M0[1,:])+C
+    end
+    # Scale to unit square
+    min_x, max_x = minimum(locs_x), maximum(locs_x)
+    min_y, max_y = minimum(locs_y), maximum(locs_y)
+    map!(z -> scaler(z, min_x, max_x), locs_x, locs_x)
+    map!(z -> scaler(z, min_y, max_y), locs_y, locs_y)
+
+    return locs_x,locs_y
+end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -192,7 +192,7 @@ Vector of Vector, Vector of node Vector for each shell.
 julia> g = graphfamous("karate")
 julia> nlist = Array{Vector{Int}}(2)
 julia> nlist[1] = [1:5]
-julia> nlist[2] = [6:num_vertiecs(g)]
+julia> nlist[2] = [6:num_vertices(g)]
 julia> locs_x, locs_y = shell_layout(g, nlist)
 ```
 """
@@ -280,3 +280,5 @@ function _spectral(A::SparseMatrixCSC)
     index = sortperm(real(eigenvalues))[2:3]
     return real(eigenvectors[:, index[1]]), real(eigenvectors[:, index[2]])
 end
+
+include("KamadaKawai.jl")


### PR DESCRIPTION
Adds `kamada_kawai_layout`,  which uses the graph-theoretic distance as the equilibrium distance between two vertices. The starting point can be supplied or will be generated from a call to `shell_layout` with shells corresponding to successive next-neighbor shells starting with the highest degree vertex. Disconnected graphs are placed side by side.