### PR TITLE
Fix for corner case where spread is zero

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -129,7 +129,11 @@ function gplot(g::AbstractGraph{T},
     min_x, max_x = extrema(locs_x)
     min_y, max_y = extrema(locs_y)
     function scaler(z, a, b)
-        2.0 * ((z - a) / (b - a)) - 1.0
+        if (a - b) == 0.0
+            return 0.5
+        else
+            return 2.0 * ((z - a) / (b - a)) - 1.0
+        end
     end
     map!(z -> scaler(z, min_x, max_x), locs_x, locs_x)
     map!(z -> scaler(z, min_y, max_y), locs_y, locs_y)


### PR DESCRIPTION
When the spread of points in either dimension is zero, the logic to rescale the location of points places all the points at the same location. This PR has a simple fix for this.

Example to demonstrate the issue

```
using GraphPlot
using LightGraphs

# case with a single point
g = SimpleGraph(1)
gplot(g, [0.0], [0.0])

# case two or more points in a line
g = SimpleGraph(3)
gplot(g, zeros(3), Float64.(1:3))
```

