### PR TITLE
typo in shell_layout example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ gplot(g, layout=spectral_layout)
 ### shell layout
 ```julia
 nlist = Vector{Vector{Int}}(undef, 2) # two shells
-nlist[1] = [1:5] # first shell
-nlist[2] = [6:nv(g)] # second shell
+nlist[1] = 1:5 # first shell
+nlist[2] = 6:nv(g) # second shell
 locs_x, locs_y = shell_layout(g, nlist)
 gplot(g, locs_x, locs_y, nodelabel=nodelabel)
 ```


### PR DESCRIPTION
The example in the main page has a type problem:
```julia
julia> nlist = Vector{Vector{Int}}(undef, 2) 
julia> nlist[1] = [1:5]
ERROR: MethodError: Cannot `convert` an object of type UnitRange{Int64} to an object of type Int64
Closest candidates are:
  convert(::Type{T}, ::T) where T<:Number at number.jl:6
  convert(::Type{T}, ::Number) where T<:Number at number.jl:7
  convert(::Type{T}, ::Ptr) where T<:Integer at pointer.jl:23
...
```
The brackets should be removed. 