### PR TITLE
Fix error in shell_layout (included in PR #186)

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -205,20 +205,20 @@ function shell_layout(g, nlist::Union{Nothing, Vector{Vector{Int}}} = nothing)
     if nv(g) == 1
         return [0.0], [0.0]
     end
-    if nlist == nothing
+    if isnothing(nlist)
         nlist = [collect(1:nv(g))]
     end
     radius = 0.0
     if length(nlist[1]) > 1
         radius = 1.0
     end
-    locs_x = Float64[]
-    locs_y = Float64[]
+    locs_x = zeros(nv(g))
+    locs_y = zeros(nv(g))
     for nodes in nlist
         # Discard the extra angle since it matches 0 radians.
         θ = range(0, stop=2pi, length=length(nodes)+1)[1:end-1]
-        append!(locs_x, radius*cos.(θ))
-        append!(locs_y, radius*sin.(θ))
+        locs_x[nodes] = radius*cos.(θ)
+        locs_y[nodes] = radius*sin.(θ)
         radius += 1.0
     end
     return locs_x, locs_y


### PR DESCRIPTION
shell layout assumed that the `nlist` had nodes in increaseing order. However, it should support lists with non-continuous vertices. This is now supported.

Fix #149 