### PR TITLE
Allow adding plot title (included in PR #186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ gplot(h)
 
 # Keyword Arguments
 + `layout` Layout algorithm: `random_layout`, `circular_layout`, `spring_layout`, `shell_layout`, `stressmajorize_layout`, `spectral_layout`. Default: `spring_layout`
++ `title` Plot title. Default: `""`
++ `title_color` Plot title color. Default: `colorant"black"`
++ `title_size` Plot title size. Default: `4.0`
++ `font_family` Font family for all text. Default: `"Helvetica"`
 + `NODESIZE` Max size for the nodes. Default: `3.0/sqrt(N)`
 + `nodesize` Relative size for the nodes, can be a Vector. Default: `1.0`
 + `nodelabel` Labels for the vertices, a Vector or nothing. Default: `nothing`

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -23,6 +23,18 @@ Layout algorithm. Currently can be one of [`random_layout`,
 `spectral_layout`].
 Default: `spring_layout`
 
+`title`
+Plot title. Default: `""`
+
+`title_color`
+Plot title color. Default: `colorant"black"`
+
+`title_size`
+Plot title size. Default: `4.0`
+
+`font_family`
+Font family for all text. Default: `"Helvetica"`
+
 `NODESIZE`
 Max size for the nodes. Default: `3.0/sqrt(N)`
 
@@ -97,6 +109,10 @@ Default: `π/5 (36 degrees)`
 """
 function gplot(g::AbstractGraph{T},
     locs_x_in::Vector{R1}, locs_y_in::Vector{R2};
+    title = "",
+    title_color = colorant"black",
+    title_size = 4.0,
+    font_family = "Helvetica",
     nodelabel = nothing,
     nodelabelc = colorant"black",
     nodelabelsize = 1.0,
@@ -227,12 +243,14 @@ function gplot(g::AbstractGraph{T},
         end
     end
 
-    compose(context(units=UnitBox(-1.2, -1.2, +2.4, +2.4)),
-            compose(context(), texts, fill(nodelabelc), stroke(nothing), fontsize(nodelabelsize)),
+    title_offset = isempty(title) ? 0 : 0.3
+    compose(context(units=UnitBox(-1.2, -1.2 - title_offset, +2.4, +2.4 + title_offset)),
+            compose(context(), text(0,-1.2,title), fill(title_color), fontsize(title_size), font(font_family)),
+            compose(context(), texts, fill(nodelabelc), fontsize(nodelabelsize), font(font_family)),
             compose(context(), nodes, fill(nodefillc), stroke(nodestrokec), linewidth(nodestrokelw)),
-            compose(context(), edgetexts, fill(edgelabelc), stroke(nothing), fontsize(edgelabelsize)),
+            compose(context(), edgetexts, fill(edgelabelc), fontsize(edgelabelsize), font(font_family)),
             compose(context(), arrows, stroke(edgestrokec), linewidth(edgelinewidth)),
-            compose(context(), lines, stroke(edgestrokec), fill(nothing), linewidth(edgelinewidth)))
+            compose(context(), lines, stroke(edgestrokec), linewidth(edgelinewidth)))
 end
 
 function gplot(g; layout::Function=spring_layout, keyargs...)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -243,9 +243,9 @@ function gplot(g::AbstractGraph{T},
         end
     end
 
-    title_offset = isempty(title) ? 0 : 0.3
+    title_offset = isempty(title) ? 0 : 0.1*title_size/4
     compose(context(units=UnitBox(-1.2, -1.2 - title_offset, +2.4, +2.4 + title_offset)),
-            compose(context(), text(0,-1.2,title), fill(title_color), fontsize(title_size), font(font_family)),
+            compose(context(), text(0, -1.2 - title_offset/2, title, hcenter, vcenter), fill(title_color), fontsize(title_size), font(font_family)),
             compose(context(), texts, fill(nodelabelc), fontsize(nodelabelsize), font(font_family)),
             compose(context(), nodes, fill(nodefillc), stroke(nodestrokec), linewidth(nodestrokelw)),
             compose(context(), edgetexts, fill(edgelabelc), fontsize(edgelabelsize), font(font_family)),


### PR DESCRIPTION
Fix #107 
-Allow add title
-Set title color and size
-Set font family for entire plot
-Remove unneded Compose objects (the ones with `nothing` as the arg)