### PR TITLE
Allow providing an AbstractRNG for seed in spring_layout

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 


### PR DESCRIPTION
This PR allows one to provide also a `Random.AbstractRNG` as a seed for `spring_layout`.

This became necessary as `Random.MersenneTwister` is not stable over different Julia versions leading to a broken test. Now we can use `StableRNG` from [StableRNGs.jl](https://github.com/JuliaRandom/StableRNGs.jl) in that test.

In addition when providing initial locations instead of a seed or a random number generator we now check the length of these vectors.